### PR TITLE
Remove function declaration from block to allow strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ function ForeverAgent(options) {
   self.minSockets = self.options.minSockets || ForeverAgent.defaultMinSockets
   self.on('free', function(socket, host, port) {
     var name = host + ':' + port
+      , onIdleError = function() {
+          socket.destroy()
+        }
     if (self.requests[name] && self.requests[name].length) {
       self.requests[name].shift().onSocket(socket)
     } else if (self.sockets[name].length < self.minSockets) {
@@ -24,9 +27,6 @@ function ForeverAgent(options) {
       self.freeSockets[name].push(socket)
       
       // if an error happens while we don't use the socket anyway, meh, throw the socket away
-      function onIdleError() {
-        socket.destroy()
-      }
       socket._onIdleError = onIdleError
       socket.on('error', onIdleError)
     } else {


### PR DESCRIPTION
Apps that depend on this module cannot run with the `--use_strict` flag due to the use of a function declaration within the body of an `if` statement.