### PR TITLE
Fix for use in strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function ForeverAgent(options) {
       self.freeSockets[name].push(socket)
       
       // if an error happens while we don't use the socket anyway, meh, throw the socket away
-      function onIdleError() {
+      var onIdleError = function() {
         socket.destroy()
       }
       socket._onIdleError = onIdleError


### PR DESCRIPTION
When running with `--use_strict` I got the following error, which this PR fixes: `SyntaxError: In strict mode code, functions can only be declared at top level or immediately within another function.`
