### PR TITLE
Use getName to get the name of the socket in node 11.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function ForeverAgent(options) {
   self.maxSockets = self.options.maxSockets || Agent.defaultMaxSockets
   self.minSockets = self.options.minSockets || ForeverAgent.defaultMinSockets
   self.on('free', function(socket, host, port) {
-    var name = host + ':' + port
+    var name = self.getName ? self.getName(host) : host + ':' + port;
     if (self.requests[name] && self.requests[name].length) {
       self.requests[name].shift().onSocket(socket)
     } else if (self.sockets[name].length < self.minSockets) {


### PR DESCRIPTION
Node 11.x now has the function `getName(options)` that returns the name of the socket.
And parameter `options` is passed in the `free` handler instead of parameters `host` and `name` https://github.com/joyent/node/blob/v0.11.11-release/lib/_http_agent.js#L204
