### PR TITLE
Specify license on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "forever-agent",
   "description": "HTTP Agent that keeps socket connections alive between keep-alive requests. Formerly part of mikeal/request, now a standalone module.",
   "version": "0.5.3",
+  "license": "Apache-2.0",
   "repository": {
     "url": "https://github.com/mikeal/forever-agent"
   },
@@ -12,6 +13,5 @@
   "optionalDependencies": {},
   "engines": {
     "node": "*"
-  },
-  "license": "Apache 2.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
   "optionalDependencies": {},
   "engines": {
     "node": "*"
-  }
+  },
+  "license": "Apache 2.0"
 }


### PR DESCRIPTION
By specifying the license on `package.json`, then automated tools such as https://github.com/pivotal/LicenseFinder can easily display which license your module is using.