### PR TITLE
Fix node 0.12 issue TypeError: Cannot read property 'length' of...

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function ForeverAgent(options) {
     var name = host + ':' + port
     if (self.requests[name] && self.requests[name].length) {
       self.requests[name].shift().onSocket(socket)
-    } else if (self.sockets[name].length < self.minSockets) {
+    } else if (self.sockets[name] && self.sockets[name].length < self.minSockets) {
       if (!self.freeSockets[name]) self.freeSockets[name] = []
       self.freeSockets[name].push(socket)
       


### PR DESCRIPTION
I have no idea why this only happens in 0.12, but this commit fixes it.

This change causes [this test](https://github.com/faradayio/request/commit/abe8b55) to pass.