### PR TITLE
Ignore destroyed sockets when they emit free event

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ function ForeverAgent(options) {
   self.on('free', function(socket, host, port) {
     var name = getConnectionName(host, port)
 
+    // Ignore destroyed sockets
+    if (!socket.writable) {
+      return;
+    }
+
     if (self.requests[name] && self.requests[name].length) {
       self.requests[name].shift().onSocket(socket)
     } else if ( self.sockets[name] && self.sockets[name].length < self.minSockets) {


### PR DESCRIPTION
These changes fix a bug when someone destroys socket when there is an active `http.ClientRequest` with associated `http.IncomingMessage`. More details in [this comment](https://github.com/thaliproject/Thali_CordovaPlugin/issues/1744#issuecomment-277996480).

This [simple gist](https://gist.github.com/chapko/237f191b6ce388ba91323a9125ba42c8) shows the bug in action