### PR TITLE
Update README.md to include copyright notice - Important for consuming Apache licensed libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@ forever-agent
 =============
 
 HTTP Agent that keeps socket connections alive between keep-alive requests. Formerly part of mikeal/request, now a standalone module.
+
+License
+=======
+Copyright 2019 Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.futurealoof.com)


### PR DESCRIPTION
Apache license needs the consuming applications to provide attribution to the license owner. Since I could not find a copyright line in the repository, it is blocking us from using the libraries list jest. Added the copyright text.

======
We need this to consume libraries like jest. Please review and approve this pull request.